### PR TITLE
Fix error when converting input to string

### DIFF
--- a/src/Assertor/AllAssertor.php
+++ b/src/Assertor/AllAssertor.php
@@ -50,7 +50,7 @@ final class AllAssertor implements Assertor
         }
 
         $params = $exception->getParams();
-        $params['name'] = $params['input'] . ', and all values of ' . stringify($asserted) . ',';
+        $params['name'] = stringify($params['input']) . ', and all values of ' . stringify($asserted) . ',';
         $exception->updateParams($params);
 
         return $exception;

--- a/src/Assertor/MaxAssertor.php
+++ b/src/Assertor/MaxAssertor.php
@@ -63,7 +63,7 @@ final class MaxAssertor implements Assertor
         }
 
         $params = $exception->getParams();
-        $params['name'] = $params['input'] . ', the maximum of ' . stringify($asserted) . ',';
+        $params['name'] = stringify($params['input']) . ', the maximum of ' . stringify($asserted) . ',';
         $exception->updateParams($params);
 
         return $exception;

--- a/src/Assertor/MinAssertor.php
+++ b/src/Assertor/MinAssertor.php
@@ -66,7 +66,7 @@ final class MinAssertor implements Assertor
         }
 
         $params = $exception->getParams();
-        $params['name'] = $params['input'] . ', the minimum of ' . stringify($asserted) . ',';
+        $params['name'] = stringify($params['input']) . ', the minimum of ' . stringify($asserted) . ',';
         $exception->updateParams($params);
 
         return $exception;

--- a/tests/unit/Assertor/AllAssertorTest.php
+++ b/tests/unit/Assertor/AllAssertorTest.php
@@ -21,6 +21,7 @@ use Respect\Assertion\Assertor\AllAssertor;
 use Respect\Validation\Exceptions\AlwaysInvalidException;
 use Respect\Validation\Factory;
 use Respect\Validation\Rules\AlwaysInvalid;
+use stdClass;
 
 use function array_chunk;
 use function count;
@@ -131,6 +132,33 @@ final class AllAssertorTest extends TestCase
             ->willThrowException($exception);
 
         $this->expectExceptionObject($exception);
+
+        $this->sut->execute($assertion, $input);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldThrowAndModifyValidationExceptionsWhenValuesInTheInputAreNonScalar(): void
+    {
+        $input = [new stdClass(), []];
+        $inInput = $input[0];
+
+        $exception = Factory::getDefaultInstance()->exception(new AlwaysInvalid(), $inInput);
+
+        $assertion = $this->createMock(Assertion::class);
+        $assertion
+            ->expects($this->once())
+            ->method('assert')
+            ->with(current($input))
+            ->willThrowException($exception);
+
+        self::assertEquals('`[object] (stdClass: { })` is always invalid', $exception->getMessage());
+
+        $this->expectException(AlwaysInvalidException::class);
+        $this->expectExceptionMessage(
+            '`[object] (stdClass: { })`, and all values of `{ [object] (stdClass: { }), { } }`, is always invalid'
+        );
 
         $this->sut->execute($assertion, $input);
     }

--- a/tests/unit/Assertor/MaxAssertorTest.php
+++ b/tests/unit/Assertor/MaxAssertorTest.php
@@ -22,7 +22,9 @@ use Respect\Assertion\Assertor\MaxAssertor;
 use Respect\Validation\Exceptions\AlwaysInvalidException;
 use Respect\Validation\Factory;
 use Respect\Validation\Rules\AlwaysInvalid;
+use stdClass;
 
+use function current;
 use function range;
 
 /**
@@ -145,6 +147,32 @@ final class MaxAssertorTest extends TestCase
             ->willThrowException($exception);
 
         $this->expectExceptionObject($exception);
+
+        $this->sut->execute($assertion, $input);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldThrowAndModifyValidationExceptionsWhenValuesInTheInputAreNonScalar(): void
+    {
+        $input = [new stdClass(), []];
+
+        $exception = Factory::getDefaultInstance()->exception(new AlwaysInvalid(), current($input));
+
+        $assertion = $this->createMock(Assertion::class);
+        $assertion
+            ->expects($this->once())
+            ->method('assert')
+            ->with(current($input))
+            ->willThrowException($exception);
+
+        self::assertEquals('`[object] (stdClass: { })` is always invalid', $exception->getMessage());
+
+        $this->expectException(AlwaysInvalidException::class);
+        $this->expectExceptionMessage(
+            '`[object] (stdClass: { })`, the maximum of `{ [object] (stdClass: { }), { } }`, is always invalid'
+        );
 
         $this->sut->execute($assertion, $input);
     }

--- a/tests/unit/Assertor/MinAssertorTest.php
+++ b/tests/unit/Assertor/MinAssertorTest.php
@@ -22,7 +22,9 @@ use Respect\Assertion\Assertor\MinAssertor;
 use Respect\Validation\Exceptions\AlwaysInvalidException;
 use Respect\Validation\Factory;
 use Respect\Validation\Rules\AlwaysInvalid;
+use stdClass;
 
+use function current;
 use function range;
 
 /**
@@ -145,6 +147,30 @@ final class MinAssertorTest extends TestCase
             ->willThrowException($exception);
 
         $this->expectExceptionObject($exception);
+
+        $this->sut->execute($assertion, $input);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldThrowAndModifyValidationExceptionsWhenValuesInTheInputAreNonScalar(): void
+    {
+        $input = [[], new stdClass()];
+
+        $exception = Factory::getDefaultInstance()->exception(new AlwaysInvalid(), current($input));
+
+        $assertion = $this->createMock(Assertion::class);
+        $assertion
+            ->expects($this->once())
+            ->method('assert')
+            ->with(current($input))
+            ->willThrowException($exception);
+
+        self::assertEquals('`{ }` is always invalid', $exception->getMessage());
+
+        $this->expectException(AlwaysInvalidException::class);
+        $this->expectExceptionMessage('`{ }`, the minimum of `{ { }, [object] (stdClass: { }) }`, is always invalid');
 
         $this->sut->execute($assertion, $input);
     }


### PR DESCRIPTION
Some assertors needed to convert the input to string when customizing exception messages, and that caused PHP errors.

I didn't make the exact change for the length rule because the input will always be an integer.