### PR TITLE
Make exception messages less verbose

### DIFF
--- a/src/Assertor/AllAssertor.php
+++ b/src/Assertor/AllAssertor.php
@@ -50,7 +50,7 @@ final class AllAssertor implements Assertor
         }
 
         $params = $exception->getParams();
-        $params['name'] = stringify($params['input']) . ', and all values of ' . stringify($asserted) . ',';
+        $params['name'] = stringify($params['input']) . ' (like all items of the input)';
         $exception->updateParams($params);
 
         return $exception;

--- a/src/Assertor/LengthAssertor.php
+++ b/src/Assertor/LengthAssertor.php
@@ -23,7 +23,6 @@ use function count;
 use function is_array;
 use function is_string;
 use function mb_strlen;
-use function Respect\Stringifier\stringify;
 
 final class LengthAssertor implements Assertor
 {
@@ -65,7 +64,7 @@ final class LengthAssertor implements Assertor
         }
 
         $params = $exception->getParams();
-        $params['name'] = $params['input'] . ', the length of ' . stringify($asserted) . ',';
+        $params['name'] = $params['input'] . ' (the length of the input)';
         $exception->updateParams($params);
 
         return $exception;

--- a/src/Assertor/MaxAssertor.php
+++ b/src/Assertor/MaxAssertor.php
@@ -63,7 +63,7 @@ final class MaxAssertor implements Assertor
         }
 
         $params = $exception->getParams();
-        $params['name'] = stringify($params['input']) . ', the maximum of ' . stringify($asserted) . ',';
+        $params['name'] = stringify($params['input']) . ' (the maximum of the input)';
         $exception->updateParams($params);
 
         return $exception;

--- a/src/Assertor/MinAssertor.php
+++ b/src/Assertor/MinAssertor.php
@@ -66,7 +66,7 @@ final class MinAssertor implements Assertor
         }
 
         $params = $exception->getParams();
-        $params['name'] = stringify($params['input']) . ', the minimum of ' . stringify($asserted) . ',';
+        $params['name'] = stringify($params['input']) . ' (the minimum of the input)';
         $exception->updateParams($params);
 
         return $exception;

--- a/tests/unit/Assertor/AllAssertorTest.php
+++ b/tests/unit/Assertor/AllAssertorTest.php
@@ -109,7 +109,7 @@ final class AllAssertorTest extends TestCase
         self::assertEquals('2 is always invalid', $exception->getMessage());
 
         $this->expectException(AlwaysInvalidException::class);
-        $this->expectExceptionMessage('2, and all values of `{ 1, 2, 3 }`, is always invalid');
+        $this->expectExceptionMessage('2 (like all items of the input) is always invalid');
 
         $this->sut->execute($assertion, $input);
     }
@@ -156,9 +156,7 @@ final class AllAssertorTest extends TestCase
         self::assertEquals('`[object] (stdClass: { })` is always invalid', $exception->getMessage());
 
         $this->expectException(AlwaysInvalidException::class);
-        $this->expectExceptionMessage(
-            '`[object] (stdClass: { })`, and all values of `{ [object] (stdClass: { }), { } }`, is always invalid'
-        );
+        $this->expectExceptionMessage('`[object] (stdClass: { })` (like all items of the input) is always invalid');
 
         $this->sut->execute($assertion, $input);
     }

--- a/tests/unit/Assertor/LengthAssertorTest.php
+++ b/tests/unit/Assertor/LengthAssertorTest.php
@@ -149,7 +149,7 @@ final class LengthAssertorTest extends TestCase
         self::assertEquals('2 is always invalid', $exception->getMessage());
 
         $this->expectException(AlwaysInvalidException::class);
-        $this->expectExceptionMessage('2, the length of `{ 1, 2, 3 }`, is always invalid');
+        $this->expectExceptionMessage('2 (the length of the input) is always invalid');
 
         $this->sut->execute($assertion, $input);
     }

--- a/tests/unit/Assertor/MaxAssertorTest.php
+++ b/tests/unit/Assertor/MaxAssertorTest.php
@@ -124,7 +124,7 @@ final class MaxAssertorTest extends TestCase
         self::assertEquals('3 is always invalid', $exception->getMessage());
 
         $this->expectException(AlwaysInvalidException::class);
-        $this->expectExceptionMessage('3, the maximum of `{ 1, 2, 3 }`, is always invalid');
+        $this->expectExceptionMessage('3 (the maximum of the input) is always invalid');
 
         $this->sut->execute($assertion, $input);
     }
@@ -170,9 +170,7 @@ final class MaxAssertorTest extends TestCase
         self::assertEquals('`[object] (stdClass: { })` is always invalid', $exception->getMessage());
 
         $this->expectException(AlwaysInvalidException::class);
-        $this->expectExceptionMessage(
-            '`[object] (stdClass: { })`, the maximum of `{ [object] (stdClass: { }), { } }`, is always invalid'
-        );
+        $this->expectExceptionMessage('`[object] (stdClass: { })` (the maximum of the input) is always invalid');
 
         $this->sut->execute($assertion, $input);
     }

--- a/tests/unit/Assertor/MinAssertorTest.php
+++ b/tests/unit/Assertor/MinAssertorTest.php
@@ -124,7 +124,7 @@ final class MinAssertorTest extends TestCase
         self::assertEquals('1 is always invalid', $exception->getMessage());
 
         $this->expectException(AlwaysInvalidException::class);
-        $this->expectExceptionMessage('1, the minimum of `{ 1, 2, 3 }`, is always invalid');
+        $this->expectExceptionMessage('1 (the minimum of the input) is always invalid');
 
         $this->sut->execute($assertion, $input);
     }
@@ -170,7 +170,7 @@ final class MinAssertorTest extends TestCase
         self::assertEquals('`{ }` is always invalid', $exception->getMessage());
 
         $this->expectException(AlwaysInvalidException::class);
-        $this->expectExceptionMessage('`{ }`, the minimum of `{ { }, [object] (stdClass: { }) }`, is always invalid');
+        $this->expectExceptionMessage('`{ }` (the minimum of the input) is always invalid');
 
         $this->sut->execute($assertion, $input);
     }


### PR DESCRIPTION
Although the current messages can give the user much information, it becomes unpractical and hard to understand what fails when making an assertion.

I wasn't using this library when I made those customizations on the exception messages. Now, getting to know more real-life use cases, like validating a collection of objects, it has become more evident that the messages are not legible as they could be.